### PR TITLE
TV devices config path fixed

### DIFF
--- a/src/homebridge/DeviceManager.js
+++ b/src/homebridge/DeviceManager.js
@@ -1,5 +1,6 @@
 import bonjour from "bonjour";
 import fs from "fs";
+import path from "path";
 import {Device} from "./Device.js";
 import EventEmitter from "events";
 
@@ -12,7 +13,7 @@ class DeviceManager extends EventEmitter {
         this.api = api;
 
         this.devices = {};
-        this.config_path = 'androidtv-config.json'
+        this.config_path = path.join(api.user.storagePath(), 'androidtv-config.json');
     }
 
     load() {


### PR DESCRIPTION
I faced an issue running HB with podman.
The working nodejs directory was something not writable by the plugin instance.
I decided it would be better to store the tv config json next to primary config in the directory specified with the -U hb-service argument.