### PR TITLE
Allow info key override on iOS remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ Example for keys :
    ]
 }
 ```
+
+Replace "Info" button on the remote:
+
+```json
+{
+   "infoKeyOverride": "KEYCODE_HOME"
+}
+```
+
 Key code are listed here:
 * [android.com/reference/android/view/KeyEvent](https://developer.android.com/reference/android/view/KeyEvent?hl=fr)
 * [androidtv-remote/src/remote/remotemessage.proto#L88](https://github.com/louis49/androidtv-remote/blob/6ff7a73f2db53da4129c809cde9c616b9babde72/src/remote/remotemessage.proto#L88)

--- a/config.schema.json
+++ b/config.schema.json
@@ -34,6 +34,11 @@
         }
       }
     },
+    "infoKeyOverride": {
+      "name": "Info Key Override Keycode",
+      "type": "string",
+      "default": "KEYCODE_INFO"
+    },
     "keys": {
       "type": "array",
       "items": {

--- a/src/homebridge/platform.js
+++ b/src/homebridge/platform.js
@@ -23,7 +23,7 @@ class AndroidTV {
         this.keys[this.api.hap.Characteristic.RemoteKey.BACK] =  RemoteKeyCode.KEYCODE_BACK;
         this.keys[this.api.hap.Characteristic.RemoteKey.EXIT] =  RemoteKeyCode.KEYCODE_HOME;
         this.keys[this.api.hap.Characteristic.RemoteKey.PLAY_PAUSE] = RemoteKeyCode.KEYCODE_MEDIA_PLAY_PAUSE;
-        this.keys[this.api.hap.Characteristic.RemoteKey.INFORMATION] = RemoteKeyCode.KEYCODE_INFO;
+        this.keys[this.api.hap.Characteristic.RemoteKey.INFORMATION] = this.config.infoKeyOverride ? RemoteKeyCode[this.config.infoKeyOverride] : RemoteKeyCode.KEYCODE_INFO;
 
         this.channelskeys = {};
         this.channelskeys[0] = RemoteKeyCode.KEYCODE_0;


### PR DESCRIPTION
Since iOS remote doesn't have a home key, allow config to override the keycode used for the info button.